### PR TITLE
use pre Issue #7 tag for GsDevKit_sys_local: https://github.com/GsDev…

### DIFF
--- a/bin/private/clone_sys_local
+++ b/bin/private/clone_sys_local
@@ -55,6 +55,7 @@ pushd ${GS_HOME} >& /dev/null
   if [ ! -d "$cloneHome" ] ; then
     ${GS_HOME}/bin/private/cloneGitHubProject $modeArg $organization GsDevKit_sys_local $cloneHome
     cd local
+    git checkout v0.0.1  # tag that pre-dates bugfix for https://github.com/GsDevKit/GsDevKit_home/issues/7
     git checkout -b gsdevkit
     cd ..
     pushd sys >& /dev/null

--- a/bin/updateGsDevKit
+++ b/bin/updateGsDevKit
@@ -118,9 +118,9 @@ if [ "$updateGsDevKitClones" = "true" ]; then
   if [ -d "$GS_CLIENT_DEV" ]; then
     $GS_CLIENT_DEV/bin/updateGsDevKit
   fi
-  if [ -d "$GS_HOME/local" ]; then
-    updateClone $GSDEVKIT_SYS_LOCAL_GIT_CHECKOUT $GSDEVKIT_SYS_LOCAL_GIT_REMOTE "$GS_HOME/local"
-  fi
+#  if [ -d "$GS_HOME/local" ]; then
+#    updateClone $GSDEVKIT_SYS_LOCAL_GIT_CHECKOUT $GSDEVKIT_SYS_LOCAL_GIT_REMOTE "$GS_HOME/local"
+#  fi
 fi
 
 if [ "$updateTodeClone" = "true" ]; then


### PR DESCRIPTION

#### Summary
 The tag  [v0.0.1 for GsDevKit_sys_local](https://github.com/GsDevKit/GsDevKit_sys_local/releases/tag/v0.0.1)  should freeze the commit used by GsDevKIt_home until the bugfix and patch scripts for Issue #7 are complete.

Main purpose of this tag is to prevent new users from using the patched GsDevKit_sys_local master branch.

#### Update Script
Required update for existing users ... necessary so that repair scripts can be run:

```
$GS_HOME/bin/updateGsDevKit -g
```

#### [Previous Pull Request](https://github.com/GsDevKit/GsDevKit_home/pull/5)
