### PR TITLE
Early Access: Seaside project work & tode bufixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - GS_VERSION=3.1.0.6 TEST=Basic
   - GS_VERSION=3.2.10  TEST=Basic
   - GS_VERSION=3.2.10  TEST=Seaside3
-#  - GS_VERSION=3.2.10  TEST=Seaside3Upgrade GS_OLD_VERSION=3.1.0.6
+  - GS_VERSION=3.2.10  TEST=Seaside3Upgrade GS_OLD_VERSION=3.1.0.6
 
 #  - GS_VERSION=3.1.0.6 TEST=BasicTodeClient
 #  - GS_VERSION=3.2.9   TEST=BasicTodeClient

--- a/bin/attachOldDevKitStone
+++ b/bin/attachOldDevKitStone
@@ -79,7 +79,7 @@ while getopts "hdmo:t" OPT ; do
       ;;
     o) oldStoneName="${OPTARG}";;
     t) todeInstalledArg=" -t ";;
-    *) echo "unknown option $OPT"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/createClient
+++ b/bin/createClient
@@ -72,7 +72,7 @@ while getopts "fht:F" OPT ; do
     f) forceArg=" -f " ;;
     F) deleteClientDir="true" ;;
     t) clientType="${OPTARG}" ;;
-    *) echo "unknown option $OPT"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/createStone
+++ b/bin/createStone
@@ -90,7 +90,7 @@ while getopts "b:fghnp:s:t:" OPT ; do
     p) todeProjectName="${OPTARG}";;
     s) snapshotFileArg=" -s ${OPTARG} ";;
     t) snapshotFileArg=" -s ${OPTARG} "; installTode="false"; todeSnapshotArg=" -t ";;
-    *) echo "unknown option $OPT"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/createStone
+++ b/bin/createStone
@@ -56,8 +56,8 @@ EXAMPLES
   $(basename $0) -g gs_329 3.2.9
   $(basename $0) gs_329 3.2.9
   $(basename $0) -f gs_329 3.2.9
-  $(basename $0) -g -s \$GS_SERVER/snapshots/extent0.tode.3.2.4.dbf gs_324 3.2.4
-  $(basename $0) -t \$GS_SERVER/snapshots/extent0.tode.3.2.4.dbf gs_324 3.2.4
+  $(basename $0) -g -s \$GS_HOME/server/snapshots/extent0.tode.3.2.4.dbf gs_324 3.2.4
+  $(basename $0) -t \$GS_HOME/server/snapshots/extent0.tode.3.2.4.dbf gs_324 3.2.4
 
 HELP
 }

--- a/bin/installClient
+++ b/bin/installClient
@@ -42,7 +42,7 @@ while getopts "hc:o:" OPT ; do
     h) usage; exit 0;;
     c) modeArg=" -c ${OPTARG} ";;
     o) organizationArg=" -o ${OPTARG} ";;
-    *) echo "unknown option: ${OPTARG}"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/installServer
+++ b/bin/installServer
@@ -42,7 +42,7 @@ while getopts "hc:o:" OPT ; do
     h) usage; exit 0;;
     c) modeArg=" -c ${OPTARG} ";;
     o) organizationArg=" -o ${OPTARG} ";;
-    *) echo "unknown option: ${OPTARG}"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/installServerClient
+++ b/bin/installServerClient
@@ -42,7 +42,7 @@ while getopts "hc:o:" OPT ; do
     h) usage; exit 0;;
     c) modeArg=" -c ${OPTARG} ";;
     o) organizationArg=" -o ${OPTARG} ";;
-    *) echo "unknown option: ${OPTARG}"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/newExtent
+++ b/bin/newExtent
@@ -85,7 +85,7 @@ while getopts "hns:t" OPT ; do
     n) noRestart="true";;
     s) snapshotFile=`realpath ${OPTARG}` ;; 
     t) attachTode="true";;
-    *) echo "unknown option: ${OPTARG}"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/newExtent
+++ b/bin/newExtent
@@ -52,8 +52,8 @@ OPTIONS
 EXAMPLES
   $(basename $0) -h
   $(basename $0) gs_329
-  $(basename $0) -s \$GS_HOME/gs_server/snapshots/extent0.tode.3.2.9.dbf gs_329
-  $(basename $0) -t -s \$GS_HOME/gs_server/snapshots/extent0.tode.3.2.9.dbf gs_329
+  $(basename $0) -s \$GS_HOME/server/snapshots/extent0.tode.3.2.9.dbf gs_329
+  $(basename $0) -t -s \$GS_HOME/server/snapshots/extent0.tode.3.2.9.dbf gs_329
 
 HELP
 }

--- a/bin/private/clone_gs_client_dev
+++ b/bin/private/clone_gs_client_dev
@@ -45,7 +45,7 @@ while getopts "hc:o:" OPT ; do
     h) usage; exit 0;;
     c) modeArg=" -c ${OPTARG} ";;
     o) organization="${OPTARG}";;
-    *) echo "unknown option $OPT"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/private/clone_gs_server
+++ b/bin/private/clone_gs_server
@@ -45,7 +45,7 @@ while getopts "hc:o:" OPT ; do
     h) usage; exit 0;;
     c) modeArg=" -c ${OPTARG} ";;
     o) organization="${OPTARG}";;
-    *) echo "unknown option $OPT"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/private/clone_sys_local
+++ b/bin/private/clone_sys_local
@@ -45,7 +45,7 @@ while getopts "hc:o:" OPT ; do
     h) usage; exit 0;;
     c) modeArg=" -c ${OPTARG} ";;
     o) organization="${OPTARG}";;
-    *) echo "unknown option $OPT"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/private/clone_todeClient
+++ b/bin/private/clone_todeClient
@@ -49,7 +49,7 @@ while getopts "hc:o:" OPT ; do
     h) usage; exit 0;;
     c) modeArg=" -c ${OPTARG} ";;
     o) organization="${OPTARG}";;
-    *) echo "unknown option $OPT"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/setupGsDevKit
+++ b/bin/setupGsDevKit
@@ -42,7 +42,7 @@ while getopts "hc:o:" OPT ; do
     h) usage; exit 0;;
     c) modeArg=" -c ${OPTARG} ";;
     o) organizationArg=" -o ${OPTARG} ";;
-    *) echo "unknown option: ${OPTARG}"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/status
+++ b/bin/status
@@ -35,7 +35,7 @@ while getopts "ahir" OPT ; do
     a) stonesArg=" -a ";;
     i) stonesArg=" -a ";;
     r) stonesArg=" -a ";;
-    *) echo "unknown option"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/todeBackup
+++ b/bin/todeBackup
@@ -49,7 +49,7 @@ while getopts "hi" OPT ; do
   case "$OPT" in
     h) usage; exit 0;;
     i) interactiveArg=" -i ";;
-    *) echo "unknown option: $OPT"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/todeIt
+++ b/bin/todeIt
@@ -46,7 +46,7 @@ while getopts "hi" OPT ; do
   case "$OPT" in
     h) usage; exit 0;;
     i) interactiveArg=" -i ";;
-    *) echo "unknown option: $OPT"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/todeRestore
+++ b/bin/todeRestore
@@ -49,7 +49,7 @@ while getopts "hi" OPT ; do
   case "$OPT" in
     h) usage; exit 0;;
     i) interactiveArg=" -i ";;
-    *) echo "unknown option: $OPT"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/bin/updateGsDevKit
+++ b/bin/updateGsDevKit
@@ -71,7 +71,7 @@ while getopts "hgtip:" OPT ; do
     g) gsDevKitArg="true"; default="false";;
     p) patchName="${OPTARG}";;
     t) todeArg="true"; default="false";;
-    *) echo "unknown option $OPT"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))

--- a/shared/projects/seaside31/bin/installServerSeaside
+++ b/shared/projects/seaside31/bin/installServerSeaside
@@ -42,13 +42,13 @@ source ${GS_HOME}/bin/defGsDevKit.env
 
 modeArg=""
 organizationArg=""
-zincHttpcPort=""
+zincHttpPort=""
 while getopts "hc:o:z:" OPT ; do
   case "$OPT" in
     h) usage; exit 0;;
     c) modeArg=" -c ${OPTARG} ";;
     o) organizationArg=" -o ${OPTARG} ";;
-    z) zincHttpcPort="${OPTARG}";;
+    z) zincHttpPort="${OPTARG}";;
     *) echo "unknown option: ${OPTARG}"; usage; exit 1;;
   esac
 done
@@ -62,8 +62,8 @@ vers=$2
 $GS_HOME/bin/setupGsDevKit $modeArg $organizationArg server $vers
 $GS_HOME/shared/projects/seaside31/bin/seasideCreateStone $stoneName $vers
 
-if [ "${zincHttpcPort}x" != "x" ] ; then
-  $GS_HOME/shared/projects/seaside31/bin/seasideWebServer $stoneName --register=zinc --port=$zincHttpcPort
+if [ "${zincHttpPort}x" != "x" ] ; then
+  $GS_HOME/shared/projects/seaside31/bin/seasideWebServer $stoneName --register=zinc --port=$zincHttpPort
 fi
 
 echo "...finished $(basename $0)"

--- a/shared/projects/seaside31/bin/seasideTest
+++ b/shared/projects/seaside31/bin/seasideTest
@@ -1,0 +1,46 @@
+#! /bin/bash
+#=========================================================================
+# Copyright (c) 2015 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+#=========================================================================
+
+echo "================="
+echo "   GsDevKit script: $(basename $0) $*"
+echo "              path: $0"
+echo "================="
+
+usage() {
+  cat <<HELP
+USAGE: $(basename $0) [-h] <stone-name>
+Run the the Seaside tests in <stone-name> using \`test --batch project Seaside\` command.
+
+OPTIONS
+  -h show usage
+
+EXAMPLES
+  $(basename $0) -h
+  $(basename $0) seaside_329
+
+HELP
+}
+
+set -e # exit on error
+if [ "${GS_HOME}x" = "x" ] ; then
+  echo "the GS_HOME environment variable needs to be defined"; exit 1
+fi
+source ${GS_HOME}/bin/defGsDevKit.env
+
+source ${GS_HOME}/bin/private/shFunctions
+getOpts_help $@ #parse standard (-h) options
+
+if [ $# -ne 1 ]; then
+  usage; exit 1
+fi
+
+stoneName="$1"
+
+$GS_HOME/bin/devKitCommandLine todeIt $stoneName << EOF
+test --batch project Seaside3
+eval \`self hasPassed ifFalse: [ System logout ].\`
+EOF
+
+echo "...finished $(basename $0)"

--- a/shared/projects/seaside31/bin/seasideUpgrade
+++ b/shared/projects/seaside31/bin/seasideUpgrade
@@ -10,7 +10,7 @@ echo "================="
 
 usage() {
   cat <<HELP
-USAGE: $(basename $0) [-h] [-l <post-load-tode-script> ] \
+USAGE: $(basename $0) [-h] [-f] [-l <post-load-tode-script> ] \
 	              <source-seaside-stone-name> \
 		      <target-seaside-stone-name> <gemstone-version>
 
@@ -19,6 +19,9 @@ version <gemstone-version> in a new stone named <target-seaside-stone-name>.
 
 OPTIONS
   -h display help
+  -f
+     Force creation of new stone by deleting 
+     \$GS_HOME/gemstone/stone/<target-stone-name> directory if it exists
   -l <post-load-tode-script>
      tODE path to the tODE script that loads your Seaside application code
 
@@ -36,11 +39,13 @@ if [ "${GS_HOME}x" = "x" ] ; then
 fi
 source ${GS_HOME}/bin/defGsDevKit.env
 
-while getopts "hl:" OPT ; do
+forceArg=""
+while getopts "hfl:" OPT ; do
   case "$OPT" in
     h) usage; exit 0;;
+    f) forceArg="-f";;
     l) postUpgradeLoadScriptPath="${OPTARG}";;
-    *) echo "unknown option $OPT"; usage; exit 1;;
+    *) usage; exit 1;;
   esac
 done
 shift $(($OPTIND - 1))
@@ -53,7 +58,9 @@ sourceStoneName="$1"
 targetStoneName="$2"
 gsvers="$3"
 
-$GS_HOME/bin/upgradeStone $sourceStoneName $targetStoneName $gsvers
+$GS_HOME/bin/upgradeStone $forceArg $sourceStoneName $targetStoneName $gsvers << EOF
+
+EOF
 
 $GS_HOME/bin/private/gsDevKitTodeCommandLine todeIt $targetStoneName << EOF
 /home/seaside/upgradeSeaside

--- a/shared/projects/seaside31/testSeaside.ston
+++ b/shared/projects/seaside31/testSeaside.ston
@@ -1,0 +1,1 @@
+TDTopezLeafNode{#name:'testSeaside',#contents:'test project Seaside3',#creationTime:DateAndTime['2015-10-21T16:30:32.5733048915863-07:00'],#modificationTime:DateAndTime['2015-10-21T16:30:51.9753050804138-07:00']}

--- a/shared/projects/seaside31/upgradeSeaside.ston
+++ b/shared/projects/seaside31/upgradeSeaside.ston
@@ -1,2 +1,2 @@
 TDTopezLeafNode{#name:'upgradeSeaside',#contents:'#called from seasideUpgrade script
-project upgrade --script=/home/seaside/installSeaside',#creationTime:DateAndTime['2015-10-20T15:28:55.5617671012878-07:00'],#modificationTime:DateAndTime['2015-10-20T16:16:49.9115369319915-07:00']}
+project upgrade --install=/home/seaside/installSeaside',#creationTime:DateAndTime['2015-10-20T15:28:55.5617671012878-07:00'],#modificationTime:DateAndTime['2015-10-20T16:16:49.9115369319915-07:00']}

--- a/sys/default/bin/validateStoneSysNodes.ston
+++ b/sys/default/bin/validateStoneSysNodes.ston
@@ -30,15 +30,22 @@ TDScriptLeafNode{#name:'validateStoneSysNodes',#contents:'[ :topez :objIn :token
         ifAbsent: [ repair := false ].
       opts
         at: \'force\'
-        ifPresent: [ :ignored | \"destroy and rebuild stoneRootDir\"
+        ifPresent: [ :ignored | 
+          \"destroy and rebuild stoneRootDir\"
           repair := true.
           opts at: \'files\' put: nil.
-          stoneRootDir exists ifTrue: [ stoneRootDir recursiveDelete ] ].
-     validateDirBlock := [ :dir | 
+          stoneRootDir exists
+            ifTrue: [ stoneRootDir recursiveDelete ] ].
+      validateDirBlock := [ :dir | 
       dir exists
         ifFalse: [ 
           repair
-            ifTrue: [ dir assureExistence ]
+            ifTrue: [ 
+              dir assureExistence. dir
+                newFileNamed: \'README.md\'
+                do: [ :file | 
+                  \"just create empty to satisfy git\"
+                   ] ]
             ifFalse: [ nil error: \'Missing directory: \' , dir pathName printString ] ] ].
       validateDirBlock value: stoneRootDir.
       validateDirBlock value: homeDir.
@@ -137,4 +144,4 @@ EXAMPLES
   /sys/default/bin/validateStoneSysNodes --stone=gsDevKit --files --repair
   /sys/default/bin/validateStoneSysNodes --stone=gsDevKit --force
 \'
-        topez: topez ] ]',#creationTime:DateAndTime['2014-11-14T16:19:26.4569790363311-08:00'],#modificationTime:DateAndTime['2015-10-03T07:57:33.7734529972076-07:00']}
+        topez: topez ] ]',#creationTime:DateAndTime['2014-11-14T16:19:26.4569790363311-08:00'],#modificationTime:DateAndTime['2015-10-21T19:04:02.0565109252929-07:00']}

--- a/tests/testSeaside3.sh
+++ b/tests/testSeaside3.sh
@@ -17,10 +17,7 @@ seasideWebServer -h
 installServerSeaside -c https -z 8383 seaside $GS_VERSION
 
 # Run Seaside unit tests
-devKitCommandLine todeIt seaside << EOF
-test --batch project Seaside3
-eval \`self hasPassed ifFalse: [ System logout ].\`
-EOF
+seasideTest seaside
 
 seasideUpdate seaside 
 

--- a/tests/testSeaside3Upgrade.sh
+++ b/tests/testSeaside3Upgrade.sh
@@ -9,4 +9,4 @@ export PATH=$GS_HOME/shared/projects/seaside31/bin:$PATH
 
 installServerSeaside -c https -z 8383 seaside $GS_OLD_VERSION
 
-upgradeSeaside seaside upgrade $GS_VERSION
+seasideUpgrade seaside upgrade $GS_VERSION


### PR DESCRIPTION
#### Summary
1. [Seaside project](https://github.com/GsDevKit/GsDevKit_home/tree/master/shared/projects/seaside31) bash scripts are shaping up nicely:
  - installServerSeaside
  - seasideCreateStone
  - seasideInstall
  - seasideTest
  - seasideUpdate
  - seasiideUpgrade
  - seasideWebServer

2. `/sys/default/bin/validateStoneSysNodes` should create a README.md files in the `/sys/stone/home` and `/sys/stone/projects` directories to coerce git to preserve the directory structure

#### tODE

dalehenrich/tode#229: `project upgrade` command implemented in support of seasideUpgrade script
dalehenrich/tode#230: Early Access bug fixes
- dalehenrich/tode#228: missing env vars in PharoCompat project entry break `project list`
- dalehenrich/tode#216: A project entry (locked) which references an non-existent directory break the project list command
- dalehenrich/tode#188: fix missing --git option
- dalehenrich/tode#159: TDSessionDescription>>fromSton: needs error handler like TodeClientElement>>fromSton:
- dalehenrich/tode#114: change to class comment does not dirty a package...
- better label on the renamed class references definition window
#### Update Script

```
$GS_HOME/bin/updateGsDevKit -g -i -t
$GS_HOME/bin todeUpdate <stone-name>
```

#### [Previous Pull Request](https://github.com/GsDevKit/GsDevKit_home/pull/9)
