### PR TITLE
Update installDevKitServerAndClient.md

### DIFF
--- a/docs/installation/installDevKitServerAndClient.md
+++ b/docs/installation/installDevKitServerAndClient.md
@@ -30,7 +30,7 @@ The following steps are involved in installing the GsDevKit server and client.  
 
    The environment variable $GS_HOME and the updated $PATH are required to use DevKit, so you should add them to your `.bashrc` or another initialization script.
    ```
-   export GS_HOME=<githubdirectory>
+   export GS_HOME=<githubdirectory>/GsDevKit_home
    export PATH=$GS_HOME/bin:$PATH
    ```
 


### PR DESCRIPTION
The export of the GS_HOME variable was referring to the <githubdirectory> where the repository was cloned, but the repository is cloned inside <githubrepository>, so it must be specified where the GsDevKit was cloned.