### PR TITLE
fix installOSPrereqs script to run on more recent versions of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,12 @@ env:
 #  - GS_VERSION=3.1.0.6 TEST=Projects2
 #  - GS_VERSION=3.2.9   TEST=Projects2
 
+addons:
+  hosts:
+    - travis.dev
+
 before_script:
+  - sudo hostname travis.dev
   - export GS_HOME="$(pwd)"
   - export PATH=$GS_HOME/bin:$PATH
   - export GS_TRAVIS=true

--- a/bin/utils/installOsPrereqs
+++ b/bin/utils/installOsPrereqs
@@ -57,7 +57,7 @@ installUbuntuPackages(){
     sudo apt-get -y install pstack
     sudo /bin/su -c "echo 'kernel.yama.ptrace_scope = 0' >>/etc/sysctl.d/10-ptrace.conf"
     if [ "${X11client}x" = "1x" ] ; then
-      sudo apt-get -y install libgl1-mesa-dev:i386
+      sudo apt-get -y install libgl1-mesa-glx:i386
       sudo apt-get -y install libxcb-dri2-0:i386
     fi
     if [ "${gemtools}" = "true" ] ; then


### PR DESCRIPTION
update installOsPrereqs with correct x11 library for travis (see https://github.com/dalehenrich/builderCI/issues/103)