### PR TITLE
Shallow clone git repositories

### DIFF
--- a/bin/private/cloneGitHubProject
+++ b/bin/private/cloneGitHubProject
@@ -21,6 +21,7 @@ The cloned directory is renamed to <directory-name> if present.
 OPTIONS
   -h
      display help
+  -b <branch name>
   -c https | ssh
      clone using https (https://github.com) or ssh (git@github.com).
      https is the default.
@@ -51,10 +52,12 @@ else
   mode="https"
 fi
 
+branch="master"
 gitArg=""
-while getopts ":hc:n" OPT ; do
+while getopts ":hb:c:n" OPT ; do
   case "$OPT" in
     h) usage; exit 0;;
+    b) branch="${OPTARG}";;
     c) mode="${OPTARG}";;
     n) gitArg=" -n ";;
     *) usage; exit 1;;
@@ -88,7 +91,7 @@ else
 fi
 
 if [ ! -d "${directoryName}" ] ; then
-  git clone --depth 1 $gitArg $url $directoryName
+  git clone --depth 1 --branch $branch $gitArg $url $directoryName
 fi
 
 echo "...finished $(basename $0)"

--- a/bin/private/cloneGitHubProject
+++ b/bin/private/cloneGitHubProject
@@ -88,7 +88,7 @@ else
 fi
 
 if [ ! -d "${directoryName}" ] ; then
-  git clone $gitArg $url $directoryName
+  git clone --depth 1 $gitArg $url $directoryName
 fi
 
 echo "...finished $(basename $0)"

--- a/sys/default/gsdevkit_bin/cloneSharedTodeProjects
+++ b/sys/default/gsdevkit_bin/cloneSharedTodeProjects
@@ -130,49 +130,39 @@ source ${GS_HOME}/bin/private/gitFunctions
 
 pushd ${GS_SHARED_REPO} >& /dev/null
   if [ ! -d "metacello-work" ] ; then
-    ${GS_HOME}/bin/private/cloneGitHubProject -n $modeArg dalehenrich metacello-work
-    checkoutClone $GS_SHARED_GIT_CHECKOUT_METACELLO ${GS_SHARED_REPO}/metacello-work $branchName
+    ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_METACELLO -n $modeArg dalehenrich metacello-work
   fi
   if [ ! -d "tode" ] ; then
-    ${GS_HOME}/bin/private/cloneGitHubProject -n $modeArg dalehenrich tode
-    checkoutClone $GS_SHARED_GIT_CHECKOUT_TODE ${GS_SHARED_REPO}/tode $branchName
+    ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_TODE -n $modeArg dalehenrich tode
   fi
   if [ ! -d "ston" ] ; then
-    ${GS_HOME}/bin/private/cloneGitHubProject -n $modeArg GsDevKit ston
-    checkoutClone $GS_SHARED_GIT_CHECKOUT_STON ${GS_SHARED_REPO}/ston $branchName
+    ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_STON -n $modeArg GsDevKit ston
   fi
   if [ "$loadClientRepos" = "true" ] ; then
     cd pharo3.0
     if [ ! -d "filetree" ] ; then
-      ${GS_HOME}/bin/private/cloneGitHubProject -n $modeArg dalehenrich filetree
-      checkoutClone $GS_SHARED_GIT_CHECKOUT_PHARO3_FILETREE ${GS_SHARED_REPO}/pharo3.0/filetree $branchName
+      ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_PHARO3_FILETREE -n $modeArg dalehenrich filetree
       fi
     cd ..
   fi
   if [ "$loadServerRepos" = "true" ] ; then
     if [ ! -d "filetree" ] ; then
-      ${GS_HOME}/bin/private/cloneGitHubProject -n $modeArg dalehenrich filetree
-      checkoutClone $GS_SHARED_GIT_CHECKOUT_GEMSTONE_FILETREE ${GS_SHARED_REPO}/filetree $branchName
+      ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_GEMSTONE_FILETREE -n $modeArg dalehenrich filetree
     fi
     if [ ! -d "Grease" ] ; then
-      ${GS_HOME}/bin/private/cloneGitHubProject -n $modeArg GsDevKit Grease
-      checkoutClone $GS_SHARED_GIT_CHECKOUT_GREASE ${GS_SHARED_REPO}/Grease $branchName
+      ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_GREASE -n $modeArg GsDevKit Grease
     fi
     if [ ! -d "PharoCompatibility" ] ; then
-      ${GS_HOME}/bin/private/cloneGitHubProject -n $modeArg glassdb PharoCompatibility
-      checkoutClone $GS_SHARED_GIT_CHECKOUT_PHARO_COMPAT ${GS_SHARED_REPO}/PharoCompatibility $branchName
+      ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_PHARO_COMPAT -n $modeArg glassdb PharoCompatibility
     fi
     if [ ! -d "glass" ] ; then
-      ${GS_HOME}/bin/private/cloneGitHubProject -n $modeArg glassdb glass
-      checkoutClone $GS_SHARED_GIT_CHECKOUT_GLASS1 ${GS_SHARED_REPO}/glass $branchName
+      ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_GLASS1 -n $modeArg glassdb glass
     fi
     if [ ! -d "rb" ] ; then
-      ${GS_HOME}/bin/private/cloneGitHubProject -n $modeArg dalehenrich rb
-      checkoutClone $GS_SHARED_GIT_CHECKOUT_RB ${GS_SHARED_REPO}/rb $branchName
+      ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_RB -n $modeArg dalehenrich rb
     fi
     if [ ! -d "zinc" ] ; then
-      ${GS_HOME}/bin/private/cloneGitHubProject -n $modeArg GsDevKit zinc
-      checkoutClone $GS_SHARED_GIT_CHECKOUT_ZINC ${GS_SHARED_REPO}/zinc $branchName
+      ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_ZINC -n $modeArg GsDevKit zinc
     fi
   fi
 popd >& /dev/null

--- a/sys/default/gsdevkit_bin/cloneSharedTodeProjects
+++ b/sys/default/gsdevkit_bin/cloneSharedTodeProjects
@@ -131,38 +131,48 @@ source ${GS_HOME}/bin/private/gitFunctions
 pushd ${GS_SHARED_REPO} >& /dev/null
   if [ ! -d "metacello-work" ] ; then
     ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_METACELLO -n $modeArg dalehenrich metacello-work
+    checkoutClone $GS_SHARED_GIT_CHECKOUT_METACELLO ${GS_SHARED_REPO}/metacello-work $branchName
   fi
   if [ ! -d "tode" ] ; then
     ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_TODE -n $modeArg dalehenrich tode
+    checkoutClone $GS_SHARED_GIT_CHECKOUT_TODE ${GS_SHARED_REPO}/tode $branchName
   fi
   if [ ! -d "ston" ] ; then
     ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_STON -n $modeArg GsDevKit ston
+    checkoutClone $GS_SHARED_GIT_CHECKOUT_STON ${GS_SHARED_REPO}/ston $branchName
   fi
   if [ "$loadClientRepos" = "true" ] ; then
     cd pharo3.0
     if [ ! -d "filetree" ] ; then
       ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_PHARO3_FILETREE -n $modeArg dalehenrich filetree
+      checkoutClone $GS_SHARED_GIT_CHECKOUT_PHARO3_FILETREE ${GS_SHARED_REPO}/pharo3.0/filetree $branchName
       fi
     cd ..
   fi
   if [ "$loadServerRepos" = "true" ] ; then
     if [ ! -d "filetree" ] ; then
       ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_GEMSTONE_FILETREE -n $modeArg dalehenrich filetree
+      checkoutClone $GS_SHARED_GIT_CHECKOUT_GEMSTONE_FILETREE ${GS_SHARED_REPO}/filetree $branchName
     fi
     if [ ! -d "Grease" ] ; then
       ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_GREASE -n $modeArg GsDevKit Grease
+      checkoutClone $GS_SHARED_GIT_CHECKOUT_GREASE ${GS_SHARED_REPO}/Grease $branchName
     fi
     if [ ! -d "PharoCompatibility" ] ; then
       ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_PHARO_COMPAT -n $modeArg glassdb PharoCompatibility
+      checkoutClone $GS_SHARED_GIT_CHECKOUT_PHARO_COMPAT ${GS_SHARED_REPO}/PharoCompatibility $branchName
     fi
     if [ ! -d "glass" ] ; then
       ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_GLASS1 -n $modeArg glassdb glass
+      checkoutClone $GS_SHARED_GIT_CHECKOUT_GLASS1 ${GS_SHARED_REPO}/glass $branchName
     fi
     if [ ! -d "rb" ] ; then
       ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_RB -n $modeArg dalehenrich rb
+      checkoutClone $GS_SHARED_GIT_CHECKOUT_RB ${GS_SHARED_REPO}/rb $branchName
     fi
     if [ ! -d "zinc" ] ; then
       ${GS_HOME}/bin/private/cloneGitHubProject -b $GS_SHARED_GIT_CHECKOUT_ZINC -n $modeArg GsDevKit zinc
+      checkoutClone $GS_SHARED_GIT_CHECKOUT_ZINC ${GS_SHARED_REPO}/zinc $branchName
     fi
   fi
 popd >& /dev/null


### PR DESCRIPTION
Shallow cloning a git repository speeds up the clone process, because it doesn't load the entire commit history. I am not sure if the history is needed, but if it's not, this change shouldn't break anything while improving CI build times (https://github.com/hpi-swa/smalltalkCI/issues/119).

See e.g.: https://www.perforce.com/blog/141218/git-beyond-basics-using-shallow-clones