### PR TITLE
Fix for Issues #126 and #127

### DIFF
--- a/bin/attachForeignStone
+++ b/bin/attachForeignStone
@@ -35,7 +35,7 @@ HELP
 }
 
 PLATFORM="`uname -sm | tr ' ' '-'`"
-if [[ "$PLATFORM" == MINGW32_NT* || "$PLATFORM" == MSYS_NT* ]] ; then
+if [[ "$PLATFORM" == MINGW32_NT* || "$PLATFORM" == MSYS_NT* || "$PLATFORM" == MINGW64_NT* ]] ; then
   exit_1_banner "This script is a server-only script and cannot be used on Windows"
 fi
 

--- a/bin/devKitCommandLine
+++ b/bin/devKitCommandLine
@@ -82,7 +82,7 @@ fi
 PLATFORM="`uname -sm | tr ' ' '-'`"
 
 case "$PLATFORM" in
-  MSYS_NT*|MINGW32_NT*) 
+  MSYS_NT*|MINGW32_NT*|MINGW64_NT*) 
     vmArgs="--headless"
     if [ "$interactive" = "true" ] ; then
       vmArgs=""

--- a/bin/downloadGemStone
+++ b/bin/downloadGemStone
@@ -67,7 +67,7 @@ case "$PLATFORM" in
       # Linux looks OK
       gsvers="GemStone64Bit${vers}-x86_64.Linux"
       ;;
-    MSYS_NT*|MINGW32_NT*)
+    MSYS_NT*|MINGW32_NT*|MINGW64_NT*)
       if  [ "$vers" \< "3.3.0"  ] ;  then 
           gsvers="GemBuilderC${vers}-x86.Windows_NT"
       else
@@ -135,7 +135,7 @@ popd >& /dev/null
 
 
 case "$PLATFORM" in
-  MSYS_NT*|MINGW32_NT*) #do nothing
+  MSYS_NT*|MINGW32_NT*|MINGW64_NT*) #do nothing
     ;;
   *)
     # Copy initial system.conf into the Seaside data directory

--- a/bin/private/installGci
+++ b/bin/private/installGci
@@ -69,7 +69,7 @@ case "$PLATFORM" in
 		gsvers="GemStone64Bit${vers}-x86_64.Linux"; libext="so" ;;
   Darwin-i386) 
 		gsvers="GemStone64Bit${vers}-i386.Darwin"; libext="dylib" ;;
-  MSYS_NT*|MINGW32_NT*) 	
+  MSYS_NT*|MINGW32_NT*|MINGW64_NT*) 	
 	if  [ "$vers" \< "3.3.0"  ] ;  then 
 			 gsvers="GemBuilderC${vers}-x86.Windows_NT"
 		else
@@ -87,7 +87,7 @@ case "$clientType" in
     case "$PLATFORM" in
       Linux-x86_64) targetLocation="${directoryPath}/pharo-vm" ;;
       Darwin-i386) targetLocation="${directoryPath}/pharo-vm/Pharo.app/Contents/MacOS/Plugins" ;;
-      MSYS_NT*|MINGW32_NT*)
+      MSYS_NT*|MINGW32_NT*|MINGW64_NT*)
         case "$vers" in
           2.4.*|3.0.*|3.1.*) sourceLocation="${gs_product}/bin" ;;
           *) sourceLocation="${gs_product}/bin32" ;;

--- a/bin/utils/installOsPrereqs
+++ b/bin/utils/installOsPrereqs
@@ -159,7 +159,7 @@ else
     Linux-x86_64)
       # Linux looks OK
       ;;
-    MSYS_NT*|MINGW32_NT*)
+    MSYS_NT*|MINGW32_NT*|MINGW64_NT*)
       # If we are running a bash script on windows, then we are done
       echo "No os prereqs installed for windows"
       exit_0_banner "...finished"

--- a/shared/bin/defGsDevKit.env
+++ b/shared/bin/defGsDevKit.env
@@ -15,7 +15,7 @@ if [ -e "${GS_SYS_LOCAL}/gsdevkit_bin/defSharedGitDevKit.env" ] ; then
   source "${GS_SYS_LOCAL}/gsdevkit_bin/defSharedGitDevKit.env"
 fi
 PLATFORM="`uname -sm | tr ' ' '-'`"
-if [[ "$PLATFORM" == MINGW32_NT* || "$PLATFORM" == MSYS_NT* ]] ; then
+if [[ "$PLATFORM" == MINGW32_NT* || "$PLATFORM" == MSYS_NT* || "$PLATFORM" == MINGW64_NT* ]] ; then
   source "${GS_SYS_DEFAULT}/gsdevkit_bin/defSharedGitDevKit_win.env"
   if [ -e "${GS_SYS_LOCAL}/gsdevkit_bin/defSharedGitDevKit_win.env" ] ; then
     source "${GS_SYS_LOCAL}/gsdevkit_bin/defSharedGitDevKit_win.env"

--- a/sys/default/server/home/utils/upgrade.ston
+++ b/sys/default/server/home/utils/upgrade.ston
@@ -1,7 +1,7 @@
 TDRawGatewayNode{#name:'upgrade',#contents:'(TDComposedDirectoryNode
     pathComposedDirectoryNodeNamed: \'upgrade\'
     topez: self topez)
-"    addPathNode: \'/sys/stone/upgrade\';" "uncomment (and use a recent version of tODE in all stoness, if you need to have stone-specific upgrade scripts"
+    addPathNode: \'/sys/stone/upgrade\';
     addPathNode: \'/sys/local/server/upgrade\';
     addPathNode: \'/sys/default/server/upgrade\';
     yourself'}


### PR DESCRIPTION
## Bugfixes

1. Issue #127: Errors during client start up are "hidden"
2. Issue #126: Another Windows version that needs to be accomodated: MINGW64_NT-6.2 x86_64

## Update Script for Client

```
$GS_HOME/binupdateGsDevKit -gc      # update GsDevKit_home and tODE clients
```

## Update Script for Server

```
$GS_HOME/bin/updateGsDevKit -g      # update GsDevKit_home
```

## Update Script for Client/Server

```
$GS_HOME/bin/updateGsDevKit -gc     # update GsDevKit_home and  tODE clients
```

## [Previous Pull Request](https://github.com/GsDevKit/GsDevKit_home/pull/124)

