### PR TITLE
Updates for smalltalkCI's new API

### DIFF
--- a/bin/smalltalkCI
+++ b/bin/smalltalkCI
@@ -88,6 +88,11 @@ else
   $GS_HOME/bin/newExtent -a $snapshotFileArg $stoneName
 fi
 
+buildEnvironment="unknown"
+if [[ "${TRAVIS:-}" = "true" ]]; then
+  buildEnvironment="travis"
+fi
+
 ${GS_HOME}/bin/devKitCommandLine serverDoIt  $stoneName << EOF
   GsDeployer bulkMigrate: [
     [
@@ -97,7 +102,7 @@ ${GS_HOME}/bin/devKitCommandLine serverDoIt  $stoneName << EOF
       onConflict: [:ex | ex allow ];
       onLock: [:ex | ex disallow ];
       load ] on: Warning do: [:w | w resume ].
-    (Smalltalk at: #SmalltalkCI) load: '${smalltalkCIConfigPath}'.
+    (Smalltalk at: #SmalltalkCI) load: '${smalltalkCIConfigPath}' env: '${buildEnvironment}'.
   ].
 
 EOF
@@ -108,10 +113,10 @@ if [ "${runSmalltalkCITests}" = "true" ]; then
   fi
   ${GS_HOME}/bin/devKitCommandLine serverDoIt  $stoneName << EOF
     SmalltalkCIGemstone 
-      loadAndTest: '${smalltalkCIConfigPath}'
+      test: '${smalltalkCIConfigPath}'
+      env: '${buildEnvironment}'
       xmlLogDirPath: '$GS_HOME/server/stones/${stoneName}/ci'
 EOF
-  python "$GS_HOME/shared/repos/smalltalkCI/lib/junit_xml_prettfier.py" "$GS_HOME/server/stones/${stoneName}/ci" 
 fi
 
 exit_0_banner "...finished"


### PR DESCRIPTION
smalltalkCI now has its own test runner and prints tests results from inside the image.
Therefore, the `junit_xml_prettfier.py` is no longer used and the API has been changed a little bit.

Related: #141 