### PR TITLE
#141 use topaz instead of gem, since SmalltalkCI now writes pretty printed test results to stdout

### DIFF
--- a/bin/smalltalkCI
+++ b/bin/smalltalkCI
@@ -106,10 +106,15 @@ if [ "${runSmalltalkCITests}" = "true" ]; then
   if [ ! -d "$GS_HOME/server/stones/${stoneName}/ci" ] ; then
     mkdir "$GS_HOME/server/stones/${stoneName}/ci"
   fi
-  ${GS_HOME}/bin/devKitCommandLine serverDoIt  $stoneName << EOF
+  ${GS_HOME}/bin/startTopaz "${stoneName}" -l -T 100000 << EOF
+  login
+  run
     SmalltalkCIGemstone 
       test: '${smalltalkCIConfigPath}'
       xmlLogDirPath: '$GS_HOME/server/stones/${stoneName}/ci'
+%
+  logout
+  exit 0
 EOF
 fi
 


### PR DESCRIPTION
test results [dumped to stdout and visible in raw log, but hidden by `travis_fold` issue in travis result view](https://github.com/GsDevKit/GsDevKit_home/issues/141#issuecomment-252535314)