### PR TITLE
installServer on Debian

### DIFF
--- a/bin/startStone
+++ b/bin/startStone
@@ -98,7 +98,7 @@ if [ ! -d "$stonePath" ] ; then
 fi
 
 # set up stone environment
-pushd $stonePath $stonePath >& /dev/null
+pushd $stonePath >& /dev/null
   source $stonePath/stone.env
 popd >& /dev/null
 

--- a/bin/utils/installOsPrereqs
+++ b/bin/utils/installOsPrereqs
@@ -72,6 +72,24 @@ installUbuntuPackages(){
     fi
 }
 
+
+installPrereqsForDebian(){
+  case "$osVersion" in
+    testing)
+      installDebianPackages
+      sudo dpkg --add-architecture i386
+      installUbuntuPackages
+      sudo apt-get -y install fonts-dejavu # ensure that DejaVu Sans Mono font present (default font for tODE)
+      sudo ln -f -s /usr/lib/i386-lin-gnu/libstdc++.so.6 /usr/lib/i386-linux-gnu/libstdc++.so
+      ;;
+    *) usage; exit_1_banner "unrecognized Debian version $os";;
+  esac
+}
+installDebianPackages(){
+  installUbuntuPackages
+}
+
+
 installPrereqsForCentOS(){
 	installCentOSPackages
 }
@@ -303,7 +321,7 @@ case "$PLATFORM" in
       # Do a trivial sudo to test we can and get the password prompt out of the way
       sudo date
 
-      if [ -f /etc/lsb-release ]; then
+      if [ -f /etc/lsb-release ] || [ -f `which lsb_release` ]; then
         osName=`lsb_release -ds | cut -d ' ' -f 1`
         osVersion=`lsb_release -rs`
       elif [ -f /etc/centos-release ]; then
@@ -317,6 +335,9 @@ case "$PLATFORM" in
       case "$osName" in
         Ubuntu)
 		  installPrereqsForUbuntu
+		  ;;
+        Debian)
+		  installPrereqsForDebian
 		  ;;
 		CentOS)
 		  installPrereqsForCentOS


### PR DESCRIPTION
Ubuntu and Debian have identical set of requirements. Minor changes to system identification to make installServer work on Debian systems. I am using Debian testing distro, so I've only pinned that particular version for now.

startStone was err'ing out due to multiple dirs given to pushd. Given that they are identical, I assumed that's a typo...