### PR TITLE
Fixed deleteClients not working on OSX with quotes for execution CMD

### DIFF
--- a/bin/deleteClient
+++ b/bin/deleteClient
@@ -46,8 +46,7 @@ fi
 for clientName in "$@"
 do
   if [ -d "${GS_CLIENT_DEV_CLIENTS}/$clientName/" ] ; then
-    deleteCmd="`\"${GS_CLIENT_DEV_CLIENTS}/$clientName/deleteClient\" $clientName`"
-    "$deleteCmd"
+    ${GS_CLIENT_DEV_CLIENTS}/$clientName/deleteClient "$clientName"
   else
     echo "client $clientName does not exist"
   fi

--- a/tests/clientTests.sh
+++ b/tests/clientTests.sh
@@ -28,3 +28,6 @@ createClient -f -t pharo gciClient40 -l -v Pharo4.0 -z $GS_HOME/shared/repos/Gem
 startClient gciClient50 -n
 stopClient gciClient50
 editClient gciClient50 "Smalltalk at: #GCIGemStoneClientTestTimeStamp put: DateAndTime current."
+
+stopClient gciClient50
+deleteClient gciClient50


### PR DESCRIPTION
At least for OSX this was the way to make it work for me.

Full explanation:

Look at this execution:

 ❯ ./deleteClient tode2                                                                                                                                                                                                                                            
=================
   GsDevKit script: deleteClient tode2
              path: ./deleteClient
=================
/opt/gemstoneAdditions/GsDevKit_home/dev/todeClient/bin/deleteClient tode2
./deleteClient: line 51: /opt/gemstoneAdditions/GsDevKit_home/dev/todeClient/bin/deleteClient tode2: No such file or directory
Error on or near line 46 :: deleteClient tode2 :: deleteClient tode2


 ❯ /opt/gemstoneAdditions/GsDevKit_home/dev/todeClient/bin/deleteClient tode2         
=================
   GsDevKit script: deleteClient tode2
              path: /opt/gemstoneAdditions/GsDevKit_home/dev/todeClient/bin/deleteClient
=================
...finished :: deleteClient tode2
