### PR TITLE
allow installation on Debian 9

### DIFF
--- a/bin/utils/installOsPrereqs
+++ b/bin/utils/installOsPrereqs
@@ -83,7 +83,7 @@ installUbuntuPackages(){
 
 installPrereqsForDebian(){
   case "$osVersion" in
-    testing | 8.3)
+    testing | 8.3 | 9.*)
       sudo dpkg --add-architecture i386
       installUbuntuPackages
       sudo apt-get -y install fonts-dejavu # ensure that DejaVu Sans Mono font present (default font for tODE)


### PR DESCRIPTION
Gemstone works fine on my Debian 9 machine, besides this one check