### PR TITLE
updated gsdevkit_launcher use of mktemp to support both linux and OSX

### DIFF
--- a/alt_bin/gsdevkit_launcher
+++ b/alt_bin/gsdevkit_launcher
@@ -219,7 +219,7 @@ else
 	ifErr2=""
 	topazExit="EXIT"
 fi
-vmScriptFile=`mktemp -p /tmp tmp.XXXXXXXXXX.gsdevkit`
+vmScriptFile=`mktemp /tmp/gsdevkit.XXXXXXXXXX`
 pwd=`pwd`
 cat - > $vmScriptFile << EOF
 


### PR DESCRIPTION
on OSX the -p <DIR> option is not supported and the XXX replacement only works if it's at the end of the file name.

command was changed to: mktemp /tmp/gsdevkit.XXXXXXXXXX